### PR TITLE
docs(website): update broken links and email address

### DIFF
--- a/src/components/common/footer/Footer.vue
+++ b/src/components/common/footer/Footer.vue
@@ -12,9 +12,9 @@
             <div class="footer_about">
               <p class="footer_about--text">
                 {{ $t('message.refer') }} <a
-                  href="https://github.com/rustsbi/prototyper"
+                  href="https://github.com/rustsbi/rustsbi"
                   target="_blank"
-                >https://github.com/rustsbi/prototyper</a>
+                >https://github.com/rustsbi/rustsbi</a>
               </p>
             </div>
             <strong class="footer_main--column_title">{{ $t('message.basicInfo') }}</strong>
@@ -35,7 +35,7 @@
               <li class="footer_contact_info--item">
                 <i
                   class="am-icon-mail-forward"
-                /><span>{{ $t('message.contactEmail') }}</span>
+                /><span v-html="$t('message.contactEmail')"></span>
               </li>
               <li class="footer_contact_info--item">
                 <i

--- a/src/langs/en.js
+++ b/src/langs/en.js
@@ -7,7 +7,7 @@ export default {
     refer: 'Please Refer To',
     documentLink: 'Documentation Link',
     contactDetails: 'Contact Details',
-    contactEmail: 'Email: rustsbi@163.com',
+    contactEmail: 'Email: <a href="mailto:contact@rustsbi.com">contact@rustsbi.com</a>',
     contactAddress: 'Address: Laboratory B513, Mingde Building, National Cybersecurity Center, Dongxihu District, Wuhan, Hubei Province',
     whatIsTitle: 'What is RustSBI',
     whatIsContent: 'RustSBI is a complete secure bootloader implementation designed to implement the RISC-V SBI interface for firmware, virtualization software, and simulators.',

--- a/src/langs/zh.js
+++ b/src/langs/zh.js
@@ -7,7 +7,7 @@ export default {
       refer: '请参阅',
       documentLink: '文档链接',
       contactDetails: '联系详情',
-      contactEmail: '联系邮箱: rustsbi@163.com',
+      contactEmail: '联系邮箱: <a href="mailto:contact@rustsbi.com">contact@rustsbi.com</a>',
       contactAddress: '总部地址: 湖北省武汉市东西湖区国家网络安全基地明德楼B513实验室',
       whatIsTitle: 'RustSBI是什么',
       whatIsContent: 'RustSBI是完整的安全引导程序实现，适用于为固件、虚拟化软件和模拟器实现RISC-V SBI接口',


### PR DESCRIPTION
This PR updates the Rust website by replacing outdated links and correcting an invalid email address to ensure all references are current and functional.  

- **What**: The website currently contains links that no longer resolve and an email address that is no longer in use. This change addresses these issues to improve the reliability of the provided resources.  
- **Why**: Broken links and invalid contact information can frustrate users seeking accurate documentation or support. Updating them maintains the project’s professionalism and usability.  
- **How**:  
  - Replaced deprecated URLs with active alternatives.  
  - Corrected the email address to a valid point of contact.  

Signed-off-by: Rongchang Lu  \<nomodeset@qq.com\>